### PR TITLE
[SURGE-3038] Update NodeJS version to 10.10.0

### DIFF
--- a/_docker/drupal/.dockerignore
+++ b/_docker/drupal/.dockerignore
@@ -6,6 +6,7 @@ Gemfile.lock
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/node_modules
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/docs
 drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/node_modules
+drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/package-lock.json
 drupal-filesystem/web/themes/custom/rhdp2/favicons
 drupal-filesystem/web/themes/custom/rhdp2/css/rhd.microsites.css
 drupal-filesystem/web/themes/custom/rhdp2/css/rhd.min.css

--- a/_docker/drupal/.dockerignore
+++ b/_docker/drupal/.dockerignore
@@ -6,6 +6,12 @@ Gemfile.lock
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/node_modules
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/docs
 drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/node_modules
+drupal-filesystem/web/themes/custom/rhdp2/favicons
+drupal-filesystem/web/themes/custom/rhdp2/css/rhd.microsites.css
+drupal-filesystem/web/themes/custom/rhdp2/css/rhd.min.css
+drupal-filesystem/web/themes/custom/rhdp2/css/rhd.min.css
+drupal-filesystem/web/themes/custom/rhdp2/js/rhd.old.min.js
+
 managed-platform/ansible/testing
 dev
 data-image

--- a/_docker/drupal/Dockerfile
+++ b/_docker/drupal/Dockerfile
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.2
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.3
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy

--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -26,12 +26,6 @@ COPY drupal-filesystem/web/modules/custom /var/www/drupal/web/modules/custom
 COPY drupal-filesystem/web/themes/custom /var/www/drupal/web/themes/custom
 
 # Build the theme
-RUN cd /var/www/drupal/web/themes/custom/rhdp/rhd-frontend \
-    && npm install \
-    && npm run-script build \
-    && rm -rf /var/www/drupal/web/themes/custom/rhdp/rhd-frontend/node_modules
-
-# Build the rhdp2 theme
 ARG FONTAWESOME_LICENCE
 RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \

--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.2
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.3
 USER root
 ARG composer_profile="production"
 CMD ["/var/www/drupal/run-httpd.sh"]

--- a/_docker/drupal/dev/build-theme.sh
+++ b/_docker/drupal/dev/build-theme.sh
@@ -23,3 +23,5 @@ cd "${FE_THEME_DIR}" \
 && cp dist/css-min/rhd.microsites.css "${DRUPAL_THEME_DIR}"/css/ \
 && cp dist/js/@rhd/rhd.old.min.js "${DRUPAL_THEME_DIR}"/js/ \
 && cp -r favicons "${DRUPAL_THEME_DIR}/"
+
+cd "${DIR}" && docker-compose exec drupal /bin/bash -c "drush cr"

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -55,8 +55,8 @@ services:
     - ./edgerc:/credentials/akamai/edgerc
     - ./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
     - ./drupal-workspace/drupal_1/drupal/credentials/phinx.yml:/var/www/drupal/phinx.yml
-    - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
-    - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
+    - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active:cached
+    - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync:cached
     - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
     - ./drupal-workspace:/drupal-workspace
     depends_on:

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -23,7 +23,7 @@ set +a
 # Login to required registries and pull required images
 docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
 docker pull docker-registry.engineering.redhat.com/developers/drupal-data:latest
-docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.2
+docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.3
 
 cd "${DIR}" && docker-compose down -v
 cd "${DIR}" && rm -rf $DIR/drupal-workspace

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -37,4 +37,8 @@ cd "${DIR}" && docker-compose run --rm bootstrap_drupal
 cd "${DIR}" && chmod -R 777 ./drupal-workspace/drupal_1/drupal/sites/default/files && chown -R "${DUID}" "${DIR}"/drupal-workspace
 cd "${DIR}" && docker-compose up -d drupal
 cd "${DIR}" && docker-compose exec -u root drupal /bin/bash -c "chown -R ${DUID}:0 /var/www/drupal/web/modules/contrib"
+
+# Build the theme for the first time
+cd "${DIR}" && ./build-theme.sh
+
 cd "${DIR}" && docker-compose logs -f drupal


### PR DESCRIPTION
Updates the Drupal base Docker image to `rhel-76.3` which has NodeJS 10.10.0 installed.